### PR TITLE
Handle error 500

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -78,5 +78,19 @@ class Plugin extends PluginBase
     {
         $this->app->register(\RLuders\JWTAuth\Providers\AuthServiceProvider::class);
         $this->app->alias('JWTAuth', \RLuders\JWTAuth\Facades\JWTAuth::class);
+
+        // Handle error
+        $this->app->error(function(\Exception $e) {
+            $error = [
+                'error' => [
+                    'code' => 'INTERNAL_ERROR',
+                    'http_code' => 500,
+                    'message' => $e->getMessage(),
+                ],
+            ];
+
+            // if (Config::get('app.debug') $error['trace'] = $e->getTrace();
+            return $error;
+        });
     }
 }


### PR DESCRIPTION
Trying to help with the #38 issue.
Followed the [OctoberCMS documentation](https://octobercms.com/docs/services/error-log#exception-handling) but there might be better ways to do it. Let me know what you think.

It will result in a error like this:
![image](https://user-images.githubusercontent.com/25110465/100678314-ca607f80-3364-11eb-9ed6-aa244035cd8d.png)

This plugin is great and I am really missing this feature.