### PR TITLE
Update AuthServiceProvider.php

### DIFF
--- a/providers/AuthServiceProvider.php
+++ b/providers/AuthServiceProvider.php
@@ -95,7 +95,7 @@ class AuthServiceProvider extends AbstractServiceProvider
     {
         // Some of default values that doesn't need to be configured by
         // the user are included on this file
-        Config::set('jwt', include realpath(__DIR__ . '/../config/jwt.php'));
+        Config::set('jwt', Config::get('rluders.jwtauth::jwt'));
 
         $attributes = PluginSettings::instance()->attributes;
         foreach ($attributes as $attr => $value) {


### PR DESCRIPTION
I had to change the JWT Provider from Lcobucci to Namshi, but when I tried to override the config in plugins/rluders/jwtauth/config/jwt.php to config/rluders/jwtauth/jwt.php as described in the OctoberCMS Documentations https://octobercms.com/docs/plugin/settings#file-configuration nothing happened and after searching for the problem turned out the config is not using the OctoberCMS way of loading configs but with a include to fix it I had to copy the loadConfiguration() to my plugin which many people will not do. Also only setting Config::set('jwt', Config::get('rluders.jwtauth::jwt')) will throw a error.

The reason I had to change the Provider is after updating the project to 469 (including plugins, without composer). I got this error: "Could not create token: Using integers for registered date claims is deprecated, please use DateTimeImmutable objects instead.". Which is fixable by changing from Lcobucci to Namshi.