### PR TITLE
feat: add userTransform event for extending auth response user data

### DIFF
--- a/http/controllers/ActivateController.php
+++ b/http/controllers/ActivateController.php
@@ -2,6 +2,7 @@
 
 namespace RLuders\JWTAuth\Http\Controllers;
 
+use Event;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use RLuders\JWTAuth\Classes\ErrorCodes;
@@ -61,6 +62,9 @@ class ActivateController extends Controller
 
         $token = $auth->fromUser($user);
 
-        return response()->json(compact('token', 'user'));
+        $userData = $user->toArray();
+        Event::dispatch('rluders.jwtauth.userTransform', [&$userData, $user]);
+
+        return response()->json(['token' => $token, 'user' => $userData]);
     }
 }

--- a/http/controllers/GetUserController.php
+++ b/http/controllers/GetUserController.php
@@ -2,6 +2,7 @@
 
 namespace RLuders\JWTAuth\Http\Controllers;
 
+use Event;
 use Illuminate\Http\Response;
 use RLuders\JWTAuth\Classes\ErrorCodes;
 use RLuders\JWTAuth\Classes\JWTAuth;
@@ -26,6 +27,9 @@ class GetUserController extends Controller
             );
         }
 
-        return response()->json(compact('user'));
+        $userData = $user->toArray();
+        Event::dispatch('rluders.jwtauth.userTransform', [&$userData, $user]);
+
+        return response()->json(['user' => $userData]);
     }
 }

--- a/http/controllers/LoginController.php
+++ b/http/controllers/LoginController.php
@@ -66,6 +66,9 @@ class LoginController extends Controller
 
         Event::dispatch('Winter.User.login', $user);
 
-        return response()->json(compact('token', 'user'));
+        $userData = $user->toArray();
+        Event::dispatch('rluders.jwtauth.userTransform', [&$userData, $user]);
+
+        return response()->json(['token' => $token, 'user' => $userData]);
     }
 }

--- a/tests/Feature/GetUserTest.php
+++ b/tests/Feature/GetUserTest.php
@@ -2,6 +2,7 @@
 
 namespace RLuders\JWTAuth\Tests\Feature;
 
+use Event;
 use RLuders\JWTAuth\Tests\TestCase;
 
 class GetUserTest extends TestCase
@@ -26,5 +27,19 @@ class GetUserTest extends TestCase
     {
         $this->getJson('/api/auth/me', ['Authorization' => 'Bearer bad.token.here'])
             ->assertStatus(401);
+    }
+
+    public function testUserTransformEventAllowsExtendingUserData(): void
+    {
+        Event::listen('rluders.jwtauth.userTransform', function (&$userData, $user) {
+            $userData['custom_field'] = 'injected';
+        });
+
+        $user  = $this->createUser(['email' => 'me2@example.com']);
+        $token = $this->tokenFor($user);
+
+        $this->getJson('/api/auth/me', ['Authorization' => "Bearer {$token}"])
+            ->assertStatus(200)
+            ->assertJson(['user' => ['custom_field' => 'injected']]);
     }
 }

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -2,6 +2,7 @@
 
 namespace RLuders\JWTAuth\Tests\Feature;
 
+use Event;
 use RLuders\JWTAuth\Tests\TestCase;
 use RLuders\JWTAuth\Models\User;
 
@@ -68,5 +69,19 @@ class LoginTest extends TestCase
         $this->postJson('/api/auth/login', ['login' => 'login@example.com'])
             ->assertStatus(422)
             ->assertJsonStructure(['errors']);
+    }
+
+    public function testUserTransformEventAllowsExtendingUserData(): void
+    {
+        Event::listen('rluders.jwtauth.userTransform', function (&$userData, $user) {
+            $userData['custom_field'] = 'injected';
+        });
+
+        $this->postJson('/api/auth/login', [
+            'login'    => 'login@example.com',
+            'password' => 'Password1!',
+        ])
+        ->assertStatus(200)
+        ->assertJson(['user' => ['custom_field' => 'injected']]);
     }
 }


### PR DESCRIPTION
## Summary

- Fires `rluders.jwtauth.userTransform` before returning `user` in login, activation, and `/me` responses
- Listeners receive `(&$userData, $user)` where `$userData` is the array representation — modify it in place to inject extra fields
- Replaces raw model pass-through with explicit array serialization, keeping response identical when no listener is registered (non-breaking)

## Usage example

```php
Event::listen('rluders.jwtauth.userTransform', function (&$userData, $user) {
    $userData['roles']       = $user->roles->pluck('name');
    $userData['permissions'] = $user->permissions->pluck('slug');
});
```

## Affected endpoints

| Endpoint | Controller |
|----------|-----------|
| `POST /api/auth/login` | `LoginController` |
| `POST /api/auth/account-activation` | `ActivateController` |
| `GET /api/auth/me` | `GetUserController` |

## Test plan

- [x] Existing tests pass (44/44)
- [x] `testUserTransformEventAllowsExtendingUserData` added to `LoginTest` and `GetUserTest`
- [x] Event correctly passes `$userData` by reference — listener modifications appear in response

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)