### PR TITLE
feat: add config file override for activation and reset password URLs

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Activation URL
+    |--------------------------------------------------------------------------
+    |
+    | Override the activation URL used in the email sent to new users when
+    | email activation mode is enabled. When set to null, the value from
+    | the backend Settings page is used. Set this to override per-environment
+    | without touching backend settings.
+    |
+    | The {code} placeholder is replaced with the activation code.
+    |
+    | Example: env('ACTIVATION_URL', null)
+    |
+    */
+
+    'activation_url' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reset Password URL
+    |--------------------------------------------------------------------------
+    |
+    | Override the password reset URL used in the forgot-password email.
+    | When set to null, the value from the backend Settings page is used.
+    |
+    | The {code} placeholder is replaced with the reset code.
+    |
+    | Example: env('RESET_PASSWORD_URL', null)
+    |
+    */
+
+    'reset_password_url' => null,
+
+];

--- a/http/controllers/ForgotPasswordController.php
+++ b/http/controllers/ForgotPasswordController.php
@@ -2,6 +2,7 @@
 
 namespace RLuders\JWTAuth\Http\Controllers;
 
+use Config;
 use Illuminate\Http\Response;
 use RLuders\JWTAuth\Models\User;
 use RLuders\JWTAuth\Models\Settings;
@@ -78,7 +79,7 @@ class ForgotPasswordController extends Controller
      */
     protected function makeResetPasswordUrl(string $code): string
     {
-        $url = Settings::get('reset_password_url');
+        $url = Config::get('rluders.jwtauth::config.reset_password_url') ?? Settings::get('reset_password_url');
         return $this->makeUrl($url, $code);
     }
 }

--- a/http/controllers/RegisterController.php
+++ b/http/controllers/RegisterController.php
@@ -2,6 +2,7 @@
 
 namespace RLuders\JWTAuth\Http\Controllers;
 
+use Config;
 use Illuminate\Http\Response;
 use RLuders\JWTAuth\Models\User;
 use Illuminate\Routing\Controller;
@@ -115,7 +116,7 @@ class RegisterController extends Controller
      */
     protected function makeActivationUrl(string $code): string
     {
-        $url = Settings::get('activation_url');
+        $url = Config::get('rluders.jwtauth::config.activation_url') ?? Settings::get('activation_url');
         return $this->makeUrl($url, $code);
     }
 }

--- a/tests/Feature/ForgotPasswordTest.php
+++ b/tests/Feature/ForgotPasswordTest.php
@@ -2,6 +2,7 @@
 
 namespace RLuders\JWTAuth\Tests\Feature;
 
+use Config;
 use Winter\Storm\Support\Facades\Mail;
 use RLuders\JWTAuth\Tests\TestCase;
 
@@ -40,5 +41,18 @@ class ForgotPasswordTest extends TestCase
 
         $this->postJson('/api/auth/forgot-password', ['email' => 'inactive@example.com'])
             ->assertStatus(404);
+    }
+
+    public function testResetPasswordUrlConfigOverrideIsRespected(): void
+    {
+        $this->createUser(['email' => 'resetconfig@example.com']);
+        Config::set('rluders.jwtauth::config.reset_password_url', 'https://custom.example.com/reset/{code}');
+
+        $this->postJson('/api/auth/forgot-password', ['email' => 'resetconfig@example.com'])
+            ->assertStatus(200);
+
+        Mail::assertSent('winter.user::mail.restore', function ($mailable) {
+            return str_starts_with($mailable->viewData['link'] ?? '', 'https://custom.example.com/reset/');
+        });
     }
 }

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -2,8 +2,10 @@
 
 namespace RLuders\JWTAuth\Tests\Feature;
 
+use Config;
 use Winter\Storm\Support\Facades\Mail;
 use RLuders\JWTAuth\Tests\TestCase;
+use Winter\User\Models\Settings as WinterUserSettings;
 
 class RegisterTest extends TestCase
 {
@@ -49,5 +51,22 @@ class RegisterTest extends TestCase
         $this->postJson('/api/auth/register', ['email' => 'x@example.com'])
             ->assertStatus(422)
             ->assertJsonStructure(['errors']);
+    }
+
+    public function testActivationUrlConfigOverrideIsRespected(): void
+    {
+        WinterUserSettings::set('activate_mode', WinterUserSettings::ACTIVATE_USER);
+        Config::set('rluders.jwtauth::config.activation_url', 'https://custom.example.com/activate/{code}');
+
+        $this->postJson('/api/auth/register', [
+            'name'                  => 'Config User',
+            'email'                 => 'configurl@example.com',
+            'password'              => 'Password1!',
+            'password_confirmation' => 'Password1!',
+        ])->assertStatus(201);
+
+        Mail::assertSent('winter.user::mail.activate', function ($mailable) {
+            return str_starts_with($mailable->viewData['link'] ?? '', 'https://custom.example.com/activate/');
+        });
     }
 }


### PR DESCRIPTION
## Summary

- Adds `config/config.php` with `activation_url` and `reset_password_url` keys (both `null` by default)
- When set to a non-null value, the config takes precedence over the backend Settings page value
- Solves the issue where `Settings::set('activation_url', ...)` clears all backend settings field visibility

## Usage

Override in a custom plugin's `boot()` method:
```php
Config::set('rluders.jwtauth::config.activation_url', env('ACTIVATION_URL', '/#/auth/activation/{code}'));
Config::set('rluders.jwtauth::config.reset_password_url', env('RESET_PASSWORD_URL', '/#/auth/reset-password/{code}'));
```

Or publish the config file and edit `config/rluders/jwtauth/config.php` in the WinterCMS root.

## Behaviour

| Config value | Source used |
|---|---|
| `null` (default) | Backend Settings page |
| non-null string | Config file / `Config::set()` call |

## Test plan

- [x] All 44 existing tests pass
- [x] `testActivationUrlConfigOverrideIsRespected` — sets config, registers with email activation mode, asserts mail link uses custom URL
- [x] `testResetPasswordUrlConfigOverrideIsRespected` — sets config, triggers forgot-password, asserts mail link uses custom URL

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)