### PR TITLE
feat!: return token and user on registration when activation mode is auto

### DIFF
--- a/http/controllers/RegisterController.php
+++ b/http/controllers/RegisterController.php
@@ -50,6 +50,14 @@ class RegisterController extends Controller
 
         if ($activationMode == 'email') {
             $this->sendActivationEmail($user);
+            return response()->json([], Response::HTTP_CREATED);
+        }
+
+        if ($activationMode == 'auto') {
+            $token = $auth->fromUser($user);
+            $userData = $user->toArray();
+            Event::dispatch('rluders.jwtauth.userTransform', [&$userData, $user]);
+            return response()->json(['token' => $token, 'user' => $userData]);
         }
 
         return response()->json([], Response::HTTP_CREATED);

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -3,6 +3,7 @@
 namespace RLuders\JWTAuth\Tests\Feature;
 
 use Illuminate\Support\Facades\RateLimiter;
+use Winter\User\Models\Settings as WinterUserSettings;
 use RLuders\JWTAuth\Tests\TestCase;
 
 class RateLimitTest extends TestCase
@@ -43,6 +44,8 @@ class RateLimitTest extends TestCase
 
     public function testRegisterReturns429AfterExceedingMaxAttempts(): void
     {
+        WinterUserSettings::set('activate_mode', WinterUserSettings::ACTIVATE_ADMIN);
+
         for ($i = 0; $i < 3; $i++) {
             $this->postJson('/api/auth/register', [
                 'name'                  => "User {$i}",

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -3,6 +3,7 @@
 namespace RLuders\JWTAuth\Tests\Feature;
 
 use Winter\Storm\Support\Facades\Mail;
+use Winter\User\Models\Settings as WinterUserSettings;
 use RLuders\JWTAuth\Tests\TestCase;
 
 class RegisterTest extends TestCase
@@ -13,8 +14,10 @@ class RegisterTest extends TestCase
         Mail::fake();
     }
 
-    public function testRegistersAUserAndReturns201(): void
+    public function testRegistersAUserAndReturns201WhenActivationModeIsManual(): void
     {
+        WinterUserSettings::set('activate_mode', WinterUserSettings::ACTIVATE_ADMIN);
+
         $this->postJson('/api/auth/register', [
             'name'                  => 'New User',
             'email'                 => 'newuser@example.com',
@@ -49,5 +52,19 @@ class RegisterTest extends TestCase
         $this->postJson('/api/auth/register', ['email' => 'x@example.com'])
             ->assertStatus(422)
             ->assertJsonStructure(['errors']);
+    }
+
+    public function testReturnsTokenAndUserWhenActivationModeIsAuto(): void
+    {
+        WinterUserSettings::set('activate_mode', WinterUserSettings::ACTIVATE_AUTO);
+
+        $this->postJson('/api/auth/register', [
+            'name'                  => 'Auto User',
+            'email'                 => 'autouser@example.com',
+            'password'              => 'Password1!',
+            'password_confirmation' => 'Password1!',
+        ])
+        ->assertStatus(200)
+        ->assertJsonStructure(['token', 'user']);
     }
 }


### PR DESCRIPTION
## Summary

- When `activate_mode` is `auto` (the default), `POST /api/auth/register` now returns `200 {token, user}` instead of `201 {}`
- Clients can immediately use the token — no second `/login` request needed
- `email` and `admin`/manual modes are unchanged (still `201 {}`)
- Also fires `rluders.jwtauth.userTransform` on the auto-activation response (consistent with other endpoints that return user data)

## Response changes

| Mode | Before | After |
|------|--------|-------|
| `auto` (default) | `201 {}` | `200 {token, user}` |
| `email` | `201 {}` | `201 {}` (unchanged) |
| `admin`/manual | `201 {}` | `201 {}` (unchanged) |

## ⚠️ Breaking change

`POST /api/auth/register` with the default `auto` activation mode changes status code from `201` to `200` and now includes a body. Clients checking for `201` or assuming an empty response must be updated.

## Test plan

- [x] All 43 tests pass
- [x] `testReturnsTokenAndUserWhenActivationModeIsAuto` — registers with auto mode, asserts `200 {token, user}`
- [x] `testRegistersAUserAndReturns201WhenActivationModeIsManual` — explicit manual mode still returns `201 {}`
- [x] `testRegisterReturns429AfterExceedingMaxAttempts` — updated to set manual mode so rate limit test remains valid

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)